### PR TITLE
sepolicy: allow dumpstate and init to work with property_type

### DIFF
--- a/private/property.te
+++ b/private/property.te
@@ -47,7 +47,7 @@ system_internal_prop(ctl_odsign_prop)
 treble_sysprop_neverallow(`
 
 enforce_sysprop_owner(`
-  neverallow domain {
+  neverallow { domain -init -dumpstate }{
     property_type
     -system_property_type
     -product_property_type


### PR DESCRIPTION
Google did an oopsie here

Change-Id: Ib4139d577f267b28132b499a6333d041bf9100d9